### PR TITLE
feature(roles-priorities): restrict actions based on role priority

### DIFF
--- a/backend-tests/AuthControllerTests.cs
+++ b/backend-tests/AuthControllerTests.cs
@@ -1,11 +1,8 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
 using CRM_ERP_UNID_TESTS;
-using CRM_ERP_UNID.Data.Models;
 using CRM_ERP_UNID.Dtos;
 using FluentAssertions;
-
-namespace Tests;
 
 [Collection("Tests")]
 public class AuthControllerTests : IClassFixture<CustomWebApiFactory>

--- a/backend-tests/DatabaseSeeder.cs
+++ b/backend-tests/DatabaseSeeder.cs
@@ -7,7 +7,6 @@ public class DatabaseSeeder
 {
     public static void Seed(AppDbContext context)
     {
-      
         context.Roles.AddRange(
             Models.Roles.Admin,
             Models.Roles.User,
@@ -63,12 +62,10 @@ public class DatabaseSeeder
             Models.RolesPermissionsResources.AdminActivateUser);
         context.RefreshTokens.AddRange(
             Models.RefreshTokens.TestUserRefreshTokenRevoked,
-            Models.RefreshTokens.TestUserExpiredRefreshToken
-        );
+            Models.RefreshTokens.TestUserExpiredRefreshToken);
         context.PasswordRecoveryTokens.AddRange(
             Models.PasswordRecoveryTokens.TestValidTokenAsynk,
-            Models.PasswordRecoveryTokens.TestExpiredTokenAsynk
-            );
+            Models.PasswordRecoveryTokens.TestExpiredTokenAsynk);
         context.SaveChanges();
     }
 }

--- a/backend-tests/DatabaseSeeder.cs
+++ b/backend-tests/DatabaseSeeder.cs
@@ -11,14 +11,19 @@ public class DatabaseSeeder
         context.Roles.AddRange(
             Models.Roles.Admin,
             Models.Roles.User,
-            Models.Roles.Guest);
+            Models.Roles.Guest,
+            Models.Roles.HighestPriority);
         context.Users.AddRange(
             Models.Users.Admin,
             Models.Users.InactiveTestUser,
-            Models.Users.TestUser);
+            Models.Users.TestUser,
+            Models.Users.HighestPriorityUser,
+            Models.Users.DeactivateHighestPriorityUser);
         context.UsersRoles.AddRange(
             Models.UsersRoles.AdminUserRoleAdmin,
-            Models.UsersRoles.TestUserRoleUser);
+            Models.UsersRoles.TestUserRoleUser,
+            Models.UsersRoles.HighestPriorityUserRoleHighestPriority,
+            Models.UsersRoles.DeactivateHighestPriorityUserRoleHighestPriority);
         context.Permissions.AddRange(
             Models.Permissions.View,
             Models.Permissions.ViewReports,

--- a/backend-tests/Models.cs
+++ b/backend-tests/Models.cs
@@ -407,7 +407,7 @@ public static class Models
             ResetId = Guid.NewGuid(),
             UserId = Models.Users.TestUser.UserId,
             ResetToken = "valid-reset-token",
-            ExpiresAt = DateTime.UtcNow.AddHours(1)
+            ExpiresAt = DateTime.UtcNow.AddDays(1)
         };
 
         public static PasswordRecoveryToken TestExpiredTokenAsynk = new PasswordRecoveryToken

--- a/backend-tests/Models.cs
+++ b/backend-tests/Models.cs
@@ -11,6 +11,7 @@ public static class Models
         {
             RoleId = Guid.Parse("aad0f879-79bf-42b5-b829-3e14b9ef0e4b"),
             RoleName = "Admin",
+            RolePriority = 10f,
             RoleDescription = "Admin role"
         };
 
@@ -18,6 +19,7 @@ public static class Models
         {
             RoleId = Guid.Parse("523a8c97-735e-41f7-b4b2-16f92791adf5"),
             RoleName = "User",
+            RolePriority = 5f,
             RoleDescription = "User role"
         };
 
@@ -25,7 +27,16 @@ public static class Models
         {
             RoleId = Guid.Parse("d9b540dd-7e8e-4aa8-a97c-3cdf3a4b08d4"),
             RoleName = "Guest",
+            RolePriority = 4.5f,
             RoleDescription = "Guest role"
+        };
+        
+        public static readonly Role HighestPriority = new Role
+        {
+            RoleId = Guid.Parse("d9b540dd-7e8e-4aa8-a97c-3cdf3a4b28d0"),
+            RoleName = "Highest Priority",
+            RolePriority = 100f,
+            RoleDescription = "Role with highest priority for tests"
         };
     }
 
@@ -51,6 +62,20 @@ public static class Models
             UserFirstName = "Test2", UserLastName = "User2", UserEmail = "test-user2@test.com",
             UserPassword = HasherHelper.HashString("123456"), IsActive = true
         };
+        
+        public static readonly User HighestPriorityUser = new User
+        {
+            UserId = Guid.Parse("2c0180d4-040c-4c00-b8f9-31f7a1e71638"), UserUserName = "highest-priority",
+            UserFirstName = "Highest", UserLastName = "Priority", UserEmail = "highest-priority@test.com",
+            UserPassword = HasherHelper.HashString("123456"), IsActive = true
+        };
+        
+        public static readonly User DeactivateHighestPriorityUser = new User
+        {
+            UserId = Guid.Parse("2c0986d4-040c-4c00-b8f9-31f7a1e71638"), UserUserName = "deactivate-highest-priority",
+            UserFirstName = "Highest", UserLastName = "Priority", UserEmail = "highest-priority@test.com",
+            UserPassword = HasherHelper.HashString("123456"), IsActive = false
+        };
     }
 
     public static class UsersRoles
@@ -63,8 +88,20 @@ public static class Models
 
         public static readonly UserRole TestUserRoleUser = new UserRole
         {
-            UserRoleId = Guid.Parse("fe904dcf-eeb1-4a71-a229-71185cc15453"), UserId = Users.InactiveTestUser.UserId,
+            UserRoleId = Guid.Parse("fe904dcf-eeb1-4a71-a229-71185cc15453"), UserId = Users.TestUser.UserId,
             RoleId = Roles.User.RoleId
+        };
+        
+        public static readonly UserRole HighestPriorityUserRoleHighestPriority = new UserRole
+        {
+            UserRoleId = Guid.Parse("fe904dcf-eeb1-4a71-a229-71185cc15017"), UserId = Users.HighestPriorityUser.UserId,
+            RoleId = Roles.HighestPriority.RoleId
+        };
+        
+        public static readonly UserRole DeactivateHighestPriorityUserRoleHighestPriority = new UserRole
+        {
+            UserRoleId = Guid.Parse("fe000dcf-eeb1-4a71-a229-71185cc15017"), UserId = Users.DeactivateHighestPriorityUser.UserId,
+            RoleId = Roles.HighestPriority.RoleId
         };
     }
 

--- a/backend-tests/UsersControllerTests.cs
+++ b/backend-tests/UsersControllerTests.cs
@@ -65,6 +65,17 @@ public class UsersControllerTests : IClassFixture<CustomWebApiFactory>
                 },
                 HttpStatusCode.Conflict
             };
+            
+            // When user has highest priority
+            yield return new object[]
+            {
+                new UpdateUserDto
+                {
+                    UserId = Models.Users.HighestPriorityUser.UserId,
+                    UserEmail = "asdsa@gmail.com"
+                },
+                HttpStatusCode.Forbidden
+            };
         }
 
         [Theory]
@@ -130,9 +141,10 @@ public class UsersControllerTests : IClassFixture<CustomWebApiFactory>
             {
                 UsersIds = new List<Guid>
                 {
-                    Models.Users.InactiveTestUser.UserId,
+                    Models.Users.InactiveTestUser.UserId, // Success
                     Models.Users.TestUser.UserId,
-                    Guid.NewGuid()
+                    Guid.NewGuid(),
+                    Models.Users.DeactivateHighestPriorityUser.UserId
                 }
             };
             
@@ -148,6 +160,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApiFactory>
             activateUsersResponseDto.Success.Count.Should().Be(1);
             activateUsersResponseDto.Failed.Count(aur => aur.Status == ResponseStatus.NotFound).Should().Be(1);
             activateUsersResponseDto.Failed.Count(aur => aur.Status == ResponseStatus.AlreadyProcessed).Should().Be(1);
+            activateUsersResponseDto.Failed.Count(aur => aur.Status == ResponseStatus.NotEnoughPriority).Should().Be(1);
         }
     }
     
@@ -165,9 +178,10 @@ public class UsersControllerTests : IClassFixture<CustomWebApiFactory>
             {
                 UsersIds = new List<Guid>
                 {
-                    Models.Users.InactiveTestUser.UserId,
-                    Models.Users.TestUser.UserId,
-                    Guid.NewGuid()
+                    Models.Users.InactiveTestUser.UserId, 
+                    Models.Users.TestUser.UserId, // Success
+                    Guid.NewGuid(),
+                    Models.Users.HighestPriorityUser.UserId
                 }
             };
             
@@ -183,6 +197,7 @@ public class UsersControllerTests : IClassFixture<CustomWebApiFactory>
             activateUsersResponseDto.Success.Count.Should().Be(1);
             activateUsersResponseDto.Failed.Count(aur => aur.Status == ResponseStatus.NotFound).Should().Be(1);
             activateUsersResponseDto.Failed.Count(aur => aur.Status == ResponseStatus.AlreadyProcessed).Should().Be(1);
+            activateUsersResponseDto.Failed.Count(aur => aur.Status == ResponseStatus.NotEnoughPriority).Should().Be(1);
         }
     }
 

--- a/backend/Constants/ResponseStatus.cs
+++ b/backend/Constants/ResponseStatus.cs
@@ -6,4 +6,5 @@ public static class ResponseStatus
     public const string NotFound = "NotFound";
     public const string Failed = "Failed";
     public const string Success = "Success";
+    public const string NotEnoughPriority = "NotEnoughPriority";
 }

--- a/backend/Container/scripts/db.sql
+++ b/backend/Container/scripts/db.sql
@@ -1,5 +1,7 @@
 ﻿-- Crear la base de datos si no existe
-IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'ERPCRMUNID')
+IF NOT EXISTS (SELECT name
+               FROM sys.databases
+               WHERE name = 'ERPCRMUNID')
     BEGIN
         CREATE DATABASE ERPCRMUNID;
     END
@@ -9,7 +11,9 @@ USE ERPCRMUNID;
 GO
 
 -- Crear un usuario de SQL Server
-IF NOT EXISTS (SELECT name FROM sys.syslogins WHERE name = 'erp_user')
+IF NOT EXISTS (SELECT name
+               FROM sys.syslogins
+               WHERE name = 'erp_user')
     BEGIN
         CREATE LOGIN erp_user WITH PASSWORD = 'YourStrongPassword123!';
     END
@@ -19,7 +23,9 @@ GO
 USE ERPCRMUNID;
 GO
 
-IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = 'erp_user')
+IF NOT EXISTS (SELECT name
+               FROM sys.database_principals
+               WHERE name = 'erp_user')
     BEGIN
         CREATE USER erp_user FOR LOGIN erp_user;
         ALTER ROLE db_owner ADD MEMBER erp_user;
@@ -62,6 +68,7 @@ CREATE TABLE Roles
 (
     RoleId          UNIQUEIDENTIFIER DEFAULT NEWID() PRIMARY KEY,
     RoleName        VARCHAR(50)  NOT NULL,
+    RolePriority    FLOAT      NOT NULL,
     RoleDescription VARCHAR(255) NULL
 );
 
@@ -114,10 +121,10 @@ DECLARE @RoleId_Admin UNIQUEIDENTIFIER = 'aad0f879-79bf-42b5-b829-3e14b9ef0e4b';
 DECLARE @RoleId_User UNIQUEIDENTIFIER = '523a8c97-735e-41f7-b4b2-16f92791adf5';
 DECLARE @RoleId_Guest UNIQUEIDENTIFIER = 'd9b540dd-7e8e-4aa8-a97c-3cdf3a4b08d4';
 
-INSERT INTO Roles (RoleId, RoleName, RoleDescription)
-VALUES (@RoleId_Admin, 'Admin', 'Admin role'),
-       (@RoleId_User, 'User', 'User role'),
-       (@RoleId_Guest, 'Guest', 'Guest role');
+INSERT INTO Roles (RoleId, RoleName, RolePriority, RoleDescription)
+VALUES (@RoleId_Admin, 'Admin', 10, 'Admin role'),
+       (@RoleId_User, 'User', 5, 'User role'),
+       (@RoleId_Guest, 'Guest', 4.5, 'Guest role');
 
 -- Insertar Usuarios
 DECLARE @UserId_Admin UNIQUEIDENTIFIER = '172422a0-5164-4470-acae-72022d3820b1';
@@ -129,8 +136,8 @@ VALUES (@UserId_Admin, 'admin', 'Admin', 'User', 'admin@admin.com',
         '$2a$10$H/STMY/cHyRA4LHxLJMUWuajKp4Fw5TiKF.UdGo5hzKqQWTMshKlW', 1),
        (@UserId_Test, 'test-user', 'Test', 'User', 'test-user@test.com',
         '$2a$10$H/STMY/cHyRA4LHxLJMUWuajKp4Fw5TiKF.UdGo5hzKqQWTMshKlW', 1),
-    (@UserId_TestDeactivated, 'test-user-deactivated', 'TestDeactivated', 'User', 'test-user-deactivated@test.com',
-     '$2a$10$H/STMY/cHyRA4LHxLJMUWuajKp4Fw5TiKF.UdGo5hzKqQWTMshKlW', 0)
+       (@UserId_TestDeactivated, 'test-user-deactivated', 'TestDeactivated', 'User', 'test-user-deactivated@test.com',
+        '$2a$10$H/STMY/cHyRA4LHxLJMUWuajKp4Fw5TiKF.UdGo5hzKqQWTMshKlW', 0)
 
 -- Insertar UsersRoles
 DECLARE @UserRoleId_Admin UNIQUEIDENTIFIER = '842193b4-5048-4cd9-be60-b7ca34319286';
@@ -166,7 +173,7 @@ VALUES (@PermissionId_View, 'View', 'Ability to view resources'),
        (@PermissionId_RevokePermission, 'Revoke_Permission', 'Revoke permission to role'),
        (@PermissionId_Delete, 'Delete', 'Delete objects'),
        (@PermissionId_DeactivateUser, 'Deactivate_User', 'Deactivate user'),
-        (@PermissionId_ActivateUser, 'Activate_User', 'Activate user')
+       (@PermissionId_ActivateUser, 'Activate_User', 'Activate user')
 
 -- Insertar Recursos
 DECLARE @ResourceId_Users UNIQUEIDENTIFIER = 'd161ec8c-7c31-4eb4-a331-82ef9e45903e';
@@ -203,8 +210,10 @@ VALUES (NEWID(), @RoleId_Admin, @PermissionId_View, @ResourceId_Users),
        (NEWID(), @RoleId_Admin, @PermissionId_Delete, @ResourceId_Roles),
        (NEWID(), @RoleId_Admin, @PermissionId_View, @ResourceId_Resources),
        (NEWID(), @RoleId_Admin, @PermissionId_View, @ResourceId_Permissions),
-       (NEWID(), @RoleId_Admin, @PermissionId_ActivateUser, NULL)
-
+       (NEWID(), @RoleId_Admin, @PermissionId_ActivateUser, NULL),
+       (NEWID(), @RoleId_User, @PermissionId_EditContent, @ResourceId_Users),
+       (NEWID(), @ROleId_User, @PermissionId_RevokeRole, NULL),
+       (NEWID(), @ROleId_User, @PermissionId_RevokePermission, NULL)
 
 -- Consultas para verificar la inserción de datos
 SELECT *

--- a/backend/Data/Models/Roles.cs
+++ b/backend/Data/Models/Roles.cs
@@ -13,6 +13,9 @@ public class Role
     [MaxLength(50)] 
     public required string RoleName { get; set; }
     
+    [Required]
+    public required double RolePriority { get; set; }
+    
     [MaxLength(255)] 
     public string? RoleDescription { get; set; }
     

--- a/backend/Dtos/RolesDtos.cs
+++ b/backend/Dtos/RolesDtos.cs
@@ -5,8 +5,13 @@ namespace CRM_ERP_UNID.Dtos;
 
 public class CreateRoleDto
 {
+    [Required]
     [MaxLength(50)]
-    public string RoleName { get; set; }
+    public required string RoleName { get; set; }
+
+    [Required]
+    [Range(0, 1000)]
+    public required double RolePriority { get; set; }
     
     [MaxLength(255)]
     public string? RoleDescription { get; set; }
@@ -17,7 +22,11 @@ public class RoleDto
     public Guid RoleId { get; set; }
     
     [MaxLength(50)]
-    public string RoleName { get; set; }
+    public required string RoleName { get; set; }
+    
+    [Required]
+    [Range(0, 1000)]
+    public required double RolePriority { get; set; }
     
     [MaxLength(255)]
     public string? RoleDescription { get; set; }
@@ -31,6 +40,9 @@ public class UpdateRoleDto
     
     [MaxLength(50)]
     public string? RoleName { get; set; }
+    
+    [Range(0, 1000)]
+    public double? RolePriority { get; set; }
     
     [MaxLength(255)]
     public string? RoleDescription { get; set; }

--- a/backend/Dtos/UsersDtos.cs
+++ b/backend/Dtos/UsersDtos.cs
@@ -28,8 +28,6 @@ public class CreateUserDto
     public string UserPassword { get; set; }
 
     [Required] public bool IsActive { get; set; } = true;
-
-    [Required] public Guid RoleId { get; set; }
 }
 
 public class UsersIdsDto

--- a/backend/Exceptions/ForbiddenException.cs
+++ b/backend/Exceptions/ForbiddenException.cs
@@ -2,10 +2,10 @@
 
 public class ForbiddenException : Exception
 {
-    public string Permission { get; }
+    public string? Permission { get; }
     public string? Resource { get; }
 
-    public ForbiddenException(string message, string permission, string? resource = null) : base(message)
+    public ForbiddenException(string message, string? permission = null, string? resource = null) : base(message)
     {
         Permission = permission;
         Resource = resource;

--- a/backend/Helpers/HttpContextHelper.cs
+++ b/backend/Helpers/HttpContextHelper.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+
+namespace CRM_ERP_UNID.Helpers;
+
+public static class HttpContextHelper
+{
+    public static Guid GetAuthenticatedUserId(IHttpContextAccessor httpContextAccessor)
+    {
+        return Guid.Parse(httpContextAccessor.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? 
+                          Guid.Empty.ToString());
+    }
+    
+    public static double[] GetAuthenticatedUserRolePriorities(IHttpContextAccessor httpContextAccessor)
+    {
+        var prioritiesClaim = httpContextAccessor.HttpContext?.User.FindFirst("RolePriorities")?.Value;
+
+        if (string.IsNullOrEmpty(prioritiesClaim))
+        {
+            return Array.Empty<double>();
+        }
+
+        return prioritiesClaim.Split(',')
+            .Select(p => double.TryParse(p, out var result) ? result : (double?)null)
+            .Where(p => p.HasValue)
+            .Select(p => p.Value)
+            .ToArray();
+    }
+}

--- a/backend/Helpers/Mapper.cs
+++ b/backend/Helpers/Mapper.cs
@@ -34,9 +34,15 @@ public static class Mapper
             Roles = user.UserRoles.Select(ur => new RoleDto
             {
                 RoleId = ur.RoleId,
+                RolePriority = ur.Role.RolePriority,
                 RoleName = ur.Role.RoleName
             }).ToList()
         };
+    }
+    
+    public static double[] UserToUserRolesPriority(User user)
+    {
+        return user.UserRoles.Select(ur => ur.Role.RolePriority).ToArray();
     }
     
     public static RoleDto RoleToRoleDto(Role role)
@@ -45,6 +51,7 @@ public static class Mapper
         {
             RoleId = role.RoleId,
             RoleName = role.RoleName,
+            RolePriority = role.RolePriority,
             RoleDescription = role.RoleDescription
         };
     }

--- a/backend/Helpers/ModelsHelper.cs
+++ b/backend/Helpers/ModelsHelper.cs
@@ -1,0 +1,39 @@
+using CRM_ERP_UNID.Exceptions;
+
+namespace CRM_ERP_UNID.Helpers;
+
+public static class ModelsHelper
+{
+    public static bool UpdateModel<TModel, TDto>(TModel model, TDto dto, Func<string, object, Task<bool>>? uniqueValidation = null)
+        where TModel : class
+        where TDto : class
+    {
+        bool hasChanges = false;
+
+        foreach (var dtoProperty in typeof(TDto).GetProperties())
+        {
+            var newValue = dtoProperty.GetValue(dto);
+            if (newValue == null) continue;
+
+            var modelProperty = typeof(TModel).GetProperty(dtoProperty.Name);
+            if (modelProperty == null) continue;
+
+            var currentValue = modelProperty.GetValue(model);
+
+            if (!object.Equals(currentValue, newValue))
+            {
+                if (uniqueValidation != null && uniqueValidation(dtoProperty.Name, newValue).Result)
+                {
+                    throw new UniqueConstraintViolationException(
+                        $"A record with {dtoProperty.Name} '{newValue}' already exists.",
+                        field: dtoProperty.Name);
+                }
+
+                modelProperty.SetValue(model, newValue);
+                hasChanges = true;
+            }
+        }
+
+        return hasChanges;
+    }
+}

--- a/backend/Modules/Auth/AuthController.cs
+++ b/backend/Modules/Auth/AuthController.cs
@@ -37,9 +37,7 @@ public class AuthController : ControllerBase
     [HttpPost("reset-password")]
     public async Task<ActionResult> ResetPassword([FromBody] ResetPasswordDto request)
     {
-        
-
-        var result = await _passwordResetService.ResetPasswordAsync(request.Token, request.NewPassword, request.ConfirmPassword);
+        var result = await _passwordResetService.ResetPasswordAsync(request);
         if (!result)
             return BadRequest("Invalid or expired token.");
         return Ok("Password reset successfully.");

--- a/backend/Modules/Auth/AuthService.cs
+++ b/backend/Modules/Auth/AuthService.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using CRM_ERP_UNID.Data.Models;
 using CRM_ERP_UNID.Dtos;
 using CRM_ERP_UNID.Exceptions;
@@ -13,42 +12,34 @@ public interface IAuthService
     Task<RefreshToken?> Logout(string refreshTokenString);
 }
 
-public class AuthService : IAuthService
+public class AuthService(
+    IUsersService _usersService,
+    ITokenService _tokenService,
+    IMailService _mailService,
+    ILogger<AuthService> _logger
+) : IAuthService
 {
-    private readonly IUsersService _usersService;
-    private readonly ITokenService _tokenService;
-    private readonly IMailService _mailService;
-    private readonly ILogger<AuthService> _logger;
-    
-    public AuthService(IUsersService usersService, ITokenService tokenService, ILogger<AuthService> logger, IMailService mailService)
-    {
-        _usersService = usersService;
-        _tokenService = tokenService;
-        _mailService = mailService;
-        _logger = logger;
-    }
-
     public async Task<TokenDto> RefreshTokenAsync(RefreshTokenEntryDto refreshTokenEntryDto)
     {
         // Get the refreshToken object 
-        RefreshToken refreshToken = await this._tokenService.GetRefreshTokenByRefreshTokenThrowsNotFound(refreshTokenEntryDto.RefreshToken);
+        RefreshToken refreshToken = await _tokenService.GetRefreshTokenByRefreshTokenThrowsNotFound(refreshTokenEntryDto.RefreshToken);
 
         // Is the same deviceId?
         if (HasherHelper.VerifyDeviceId(refreshToken.DeviceId, refreshTokenEntryDto.DeviceId) == false)
         {
-            await _tokenService.RevokeRefreshsTokensByUserId(refreshToken.UserId);
+            await _tokenService.RevokeRefreshTokensByUserId(refreshToken.UserId);
             throw new UnauthorizedException(message: "Device not authorizated to refresh the token.", reason: "WrongDeviceId");
         }
         
-        this.ValidateRefreshToken(refreshToken);
+        ValidateRefreshToken(refreshToken);
 
         // Get the user
-        User user = await this._usersService.GetByIdThrowsNotFoundAsync(refreshToken.UserId);
+        User user = await _usersService.GetByIdThrowsNotFoundAsync(refreshToken.UserId);
 
         // Create the new Token Data
         TokenDto newTokenDto = new TokenDto
         {
-            Token = this._tokenService.GenerateAccessToken(user),
+            Token = _tokenService.GenerateAccessToken(user),
             RefreshToken = refreshToken.Token
         };
         
@@ -60,7 +51,7 @@ public class AuthService : IAuthService
         _logger.LogInformation("User with UserName {UserUserName} requested Login", loginUserDto.UserUserName);
         
         // Exist User
-        User? user = await this._usersService.GetByUserNameThrowsNotFound(loginUserDto.UserUserName);
+        User? user = await _usersService.GetByUserNameThrowsNotFound(loginUserDto.UserUserName);
 
         // Correct password?
         if (!HasherHelper.VerifyHash(loginUserDto.UserPassword, user.UserPassword))
@@ -81,20 +72,20 @@ public class AuthService : IAuthService
         
         return new TokenDto
         {
-            Token = this._tokenService.GenerateAccessToken(user),
-            RefreshToken = (await this._tokenService.GenerateAndStoreRefreshTokenAsync(user.UserId, loginUserDto.DeviceId)).Token
+            Token = _tokenService.GenerateAccessToken(user),
+            RefreshToken = (await _tokenService.GenerateAndStoreRefreshTokenAsync(user.UserId, loginUserDto.DeviceId)).Token
         };
     }
 
     public async Task<RefreshToken?> Logout(string refreshTokenString)
     {
         // 1. Get the refresh token
-        RefreshToken? refreshToken = await this._tokenService.GetRefreshTokenByRefreshTokenThrowsNotFound(refreshTokenString);
+        RefreshToken? refreshToken = await _tokenService.GetRefreshTokenByRefreshTokenThrowsNotFound(refreshTokenString);
 
-        this.ValidateRefreshToken(refreshToken);
+        ValidateRefreshToken(refreshToken);
 
         // 2. Revoke refresh token and return
-        await this._tokenService.RevokeRefreshTokenByObject(refreshToken);
+        await _tokenService.RevokeRefreshTokenByObject(refreshToken);
 
         return refreshToken;
     }

--- a/backend/Modules/Generic/GenericService.cs
+++ b/backend/Modules/Generic/GenericService.cs
@@ -23,15 +23,10 @@ public interface IGenericServie<T> where T : class
         Func<IQueryable<T>, IQueryable<T>> queryModifier = null);
 }
 
-public class GenericService<T> : IGenericServie<T> where T : class
+public class GenericService<T>(
+    IGenericRepository<T> _genericRepository
+    ) : IGenericServie<T> where T : class
 {
-    private readonly IGenericRepository<T> _genericRepository;
-
-    public GenericService(IGenericRepository<T> genericRepository)
-    {
-        _genericRepository = genericRepository;
-    }
-
     public async Task<T?> GetById(Guid id, Func<IQueryable<T>, IQueryable<T>>? include = null)
     {
         return await _genericRepository.GetByIdAsync(id, include);

--- a/backend/Modules/Permissions/PermissionService.cs
+++ b/backend/Modules/Permissions/PermissionService.cs
@@ -1,6 +1,5 @@
 using CRM_ERP_UNID.Dtos;
 using CRM_ERP_UNID.Data.Models;
-using CRM_ERP_UNID.Exceptions;
 
 namespace CRM_ERP_UNID.Modules;
 
@@ -13,17 +12,11 @@ public interface IPermissionService
     Task<bool> ExistById(Guid id);
 }
 
-public class PermissionService : IPermissionService
+public class PermissionService(
+    IPermissionRepository _permissionRepository,
+    IGenericServie<Permission> _genericService
+) : IPermissionService
 {
-    private readonly IPermissionRepository _permissionRepository;
-    private readonly IGenericServie<Permission> _genericService;
-    
-    public PermissionService(IPermissionRepository permissionRepository, IGenericServie<Permission> genericService)
-    {
-        _permissionRepository = permissionRepository;
-        _genericService = genericService;
-    }
-
     public async Task<GetAllResponseDto<Permission>> GetAllAsync(GetAllDto getAllDto)
     {
         return await _genericService.GetAllAsync(getAllDto);

--- a/backend/Modules/Resource/ResourceService.cs
+++ b/backend/Modules/Resource/ResourceService.cs
@@ -11,15 +11,10 @@ public interface IResourceService
     Task<bool> ExistById(Guid id);
 }
 
-public class ResourceService : IResourceService
+public class ResourceService(
+    IGenericServie<Resource> _genericService
+) : IResourceService
 {
-    private readonly IGenericServie<Resource> _genericService;
-    
-    public ResourceService(IGenericServie<Resource> genericService)
-    {
-        _genericService = genericService;
-    }
-
     public async Task<GetAllResponseDto<Resource>> GetAllAsync(GetAllDto getAllDto)
     {
         return await _genericService.GetAllAsync(getAllDto);
@@ -29,7 +24,7 @@ public class ResourceService : IResourceService
     {
         return await _genericService.GetByIdThrowsNotFoundAsync(id);
     }
-    
+
     public async Task<Resource> GetByNameThrowsNotFoundAsync(string resourceName)
     {
         return await _genericService.GetFirstThrowsNotFoundAsync(r => r.ResourceName, resourceName);

--- a/backend/Modules/Roles/PriorityValidationService.cs
+++ b/backend/Modules/Roles/PriorityValidationService.cs
@@ -1,0 +1,65 @@
+using CRM_ERP_UNID.Data.Models;
+using CRM_ERP_UNID.Exceptions;
+using CRM_ERP_UNID.Helpers;
+
+namespace CRM_ERP_UNID.Modules;
+
+public interface IPriorityValidationService
+{
+    bool ValidateRolePriority(Role role);
+    bool ValidateUserPriority(User user);
+    void ValidateRolePriorityThrowsForbiddenException(Role role);
+    void ValidateUserPriorityThrowsForbiddenException(User user);
+    void ValidatePriorityThrowsForbiddenException(params double[] rolePriorities);
+}
+
+public class PriorityValidationService(
+    IHttpContextAccessor _httpContextAccessor
+) : IPriorityValidationService
+{
+    public bool ValidateRolePriority(Role role) 
+        => ValidatePriorityWithoutException(role.RolePriority);
+
+    public bool ValidateUserPriority(User user) 
+        => ValidatePriorityWithoutException(Mapper.UserToUserRolesPriority(user));
+
+    public void ValidateRolePriorityThrowsForbiddenException(Role role)
+    {
+        ValidatePriorityThrowsForbiddenException(role.RolePriority);
+    }
+    
+    public void ValidateUserPriorityThrowsForbiddenException(User user)
+    {
+        ValidatePriorityThrowsForbiddenException(Mapper.UserToUserRolesPriority(user));
+    }
+    
+    public void ValidatePriorityThrowsForbiddenException(params double[] rolePriorities)
+    {
+        double[] authenticatedUserRolePriorities = HttpContextHelper.GetAuthenticatedUserRolePriorities(_httpContextAccessor);
+        
+        if (!authenticatedUserRolePriorities.Any())
+            throw new ForbiddenException("Authenticated user has no roles assigned");
+
+        if (!rolePriorities.Any())
+            return;
+
+        bool hasPriority = authenticatedUserRolePriorities.Any(authPriority =>
+            rolePriorities.Any(rolePriority => authPriority > rolePriority));
+
+        if (!hasPriority)
+            throw new ForbiddenException("Not enough permission to make the action");
+    }
+
+    private bool ValidatePriorityWithoutException(params double[] rolePriorities)
+    {
+        try
+        {
+            ValidatePriorityThrowsForbiddenException(rolePriorities);
+            return true;
+        }
+        catch (ForbiddenException)
+        {
+            return false;
+        }
+    }
+}

--- a/backend/Modules/Roles/RoleController.cs
+++ b/backend/Modules/Roles/RoleController.cs
@@ -33,13 +33,7 @@ public class RoleController : ControllerBase
     {
         Role role = await _roleService.GetByIdThrowsNotFoundAsync(id);
 
-        RoleDto roleDto = new RoleDto
-        {
-            RoleId = role.RoleId,
-            RoleName = role.RoleName,
-        };
-
-        return Ok(roleDto);
+        return Ok(Mapper.RoleToRoleDto(role));
     }
 
     [HttpGet("get-by-name")]
@@ -48,13 +42,7 @@ public class RoleController : ControllerBase
     {
         Role role = await _roleService.GetByNameThrowsNotFoundAsync(roleName);
 
-        RoleDto roleDto = new RoleDto
-        {
-            RoleId = role.RoleId,
-            RoleName = role.RoleName,
-        };
-
-        return Ok(roleDto);
+        return Ok(Mapper.RoleToRoleDto(role));
     }
     
     [HttpPost("get-all")]

--- a/backend/Modules/Roles/RoleRepository.cs
+++ b/backend/Modules/Roles/RoleRepository.cs
@@ -12,23 +12,18 @@ public interface IRoleRepository
     void Add(Role role);
 }
 
-public class RoleRepository : IRoleRepository
+public class RoleRepository(
+    AppDbContext _context
+    ) : IRoleRepository
 {
-    private readonly AppDbContext _context;
-
-    public RoleRepository(AppDbContext context)
-    {
-        _context = context;
-    }
-
     public void Add(Role role)
-    {
-        this._context.Roles.Add(role);
+    { 
+        _context.Roles.Add(role);
     }
 
     public async Task SaveChangesAsync()
     {
-        await this._context.SaveChangesAsync();
+        await _context.SaveChangesAsync();
     }
     
     public void Update(Role role)

--- a/backend/Modules/RolesPermissionsResources/RolesPermissionsResourcesService.cs
+++ b/backend/Modules/RolesPermissionsResources/RolesPermissionsResourcesService.cs
@@ -1,8 +1,8 @@
-﻿using System.Security.Claims;
-using CRM_ERP_UNID.Constants;
+﻿using CRM_ERP_UNID.Constants;
 using CRM_ERP_UNID.Data.Models;
 using CRM_ERP_UNID.Dtos;
 using CRM_ERP_UNID.Exceptions;
+using CRM_ERP_UNID.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace CRM_ERP_UNID.Modules;
@@ -17,38 +17,143 @@ public interface IRolesPermissionsResourcesService
     Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> AssignPermissionsToRolesAsync(
         PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto);
 
-    Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> RevokePermissionsToRolesAsync(PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto);
+    Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> RevokePermissionsToRolesAsync(
+        PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto);
 
     Task<GetAllResponseDto<RolePermissionResource>> GetAllAsync(GetAllDto getAllDto);
 }
 
-public class RolesPermissionsResourcesService : IRolesPermissionsResourcesService
+public class RolesPermissionsResourcesService(
+    IRolesPermissionsResourcesRepository _rolesPermissionsResourcesRepository,
+    IRoleService _roleService,
+    IPermissionService _permissionService,
+    IGenericServie<RolePermissionResource> _genericService,
+    IResourceService _resourceService,
+    ILogger<RolesPermissionsResourcesService> _logger,
+    IHttpContextAccessor _httpContextAccessor,
+    IPriorityValidationService _priorityValidationService
+) : IRolesPermissionsResourcesService
 {
-    private readonly IRolesPermissionsResourcesRepository _rolesPermissionsResourcesRepository;
-    private readonly IRoleService _roleService;
-    private readonly IPermissionService _permissionService;
-    private readonly IGenericServie<RolePermissionResource> _genericService;
-    private readonly IResourceService _resourceService;
-    private readonly ILogger<RolesPermissionsResourcesService> _logger;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-
-    private Guid AuthenticatedUserId =>
-        Guid.Parse(_httpContextAccessor.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ??
-                   Guid.Empty.ToString());
-
-    public RolesPermissionsResourcesService(IRolesPermissionsResourcesRepository rolesPermissionsResourcesRepository,
-        IRoleService roleService,
-        IPermissionService permissionService, IGenericServie<RolePermissionResource> genericService,
-        IResourceService resourceService, ILogger<RolesPermissionsResourcesService> logger,
-        IHttpContextAccessor httpContextAccessor)
+    public async Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> RevokePermissionsToRolesAsync(
+        PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto)
     {
-        _rolesPermissionsResourcesRepository = rolesPermissionsResourcesRepository;
-        _roleService = roleService;
-        _permissionService = permissionService;
-        _genericService = genericService;
-        _resourceService = resourceService;
-        _logger = logger;
-        _httpContextAccessor = httpContextAccessor;
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
+        ResponsesDto<RolePermissionResourceResponseStatusDto> responseDto = new();
+
+        _logger.LogInformation(
+            "User with Id {authenticatedUserId} requested RevokePermissionToRoleAsync with the object {permissionsResourcesAndRolesIdsDto}",
+            authenticatedUserId, permissionsResourcesAndRolesIdsDto);
+
+        foreach (PermissionResourceAndRoleIdsDto permissionResourceAndRoleIdsDto in permissionsResourcesAndRolesIdsDto
+                     .PermissionResourceAndRoleIds)
+        {
+            RolePermissionResource? rolePermissionResource =
+                await GetByRoleIdPermissionIdResourceIdAsync(permissionResourceAndRoleIdsDto.RoleId,
+                    permissionResourceAndRoleIdsDto.PermissionId, permissionResourceAndRoleIdsDto.ResourceId);
+
+            if (rolePermissionResource == null)
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.NotFound,
+                    "PermissionId", "Permission not found"); continue;
+            }
+
+            Role role = await _roleService.GetByIdThrowsNotFoundAsync(permissionResourceAndRoleIdsDto.RoleId);
+
+            if (!_priorityValidationService.ValidateRolePriority(role))
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.NotEnoughPriority,
+                    "RoleId", "Not have enough priority to modify that role"); continue;
+            }
+
+            // Remove from database
+            _rolesPermissionsResourcesRepository.Remove(rolePermissionResource);
+            await _rolesPermissionsResourcesRepository.SaveChangesAsync();
+
+            responseDto.Success.Add(new RolePermissionResourceResponseStatusDto
+            {
+                PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
+                Status = ResponseStatus.Success,
+                Message = "Success"
+            });
+        }
+
+        _logger.LogInformation(
+            "User with Id {authenticatedUserId} requested AssignPermissionToRoleAsync and the result was {responsesDto}",
+            authenticatedUserId, responseDto);
+
+        return responseDto;
+    }
+
+    public async Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> AssignPermissionsToRolesAsync(
+        PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto)
+    {
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
+        ResponsesDto<RolePermissionResourceResponseStatusDto> responseDto = new();
+
+        _logger.LogInformation(
+            "User with Id {authenticatedUserId} requested AssignPermissionToRoleAsync with the object {permissionsResourcesAndRolesIdsDto}",
+            authenticatedUserId, permissionsResourcesAndRolesIdsDto);
+
+        foreach (PermissionResourceAndRoleIdsDto permissionResourceAndRoleIdsDto in permissionsResourcesAndRolesIdsDto
+                     .PermissionResourceAndRoleIds)
+        {
+            if (await ArePermissionIdResourceIdAssignedToRoleIdAsync(permissionResourceAndRoleIdsDto.RoleId,
+                    permissionResourceAndRoleIdsDto.PermissionId, permissionResourceAndRoleIdsDto.ResourceId))
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.AlreadyProcessed,
+                    "PermissionId", "Already assigned"); continue;
+            }
+
+            Role? role = await _roleService.GetById(permissionResourceAndRoleIdsDto.RoleId);
+
+            if (role == null)
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.NotFound,
+                    "RoleId", "Role not found"); continue;
+            }
+
+            if (!await _permissionService.ExistById(permissionResourceAndRoleIdsDto.PermissionId))
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.NotFound,
+                    "PermissionId", "Permission not found"); continue;
+            }
+
+            if (permissionResourceAndRoleIdsDto.ResourceId != null &&
+                !await _resourceService.ExistById(permissionResourceAndRoleIdsDto.ResourceId.Value))
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.NotFound,
+                    "ResourceId", "Resource not found"); continue;
+            }
+
+            if (!_priorityValidationService.ValidateRolePriority(role))
+            {
+                AddFailedResponseDto(responseDto, permissionResourceAndRoleIdsDto, ResponseStatus.NotEnoughPriority,
+                    "RoleId", "Not have enough priority to modify that role"); continue;
+            }
+
+            RolePermissionResource rolePermissionResource = new RolePermissionResource
+            {
+                RoleId = permissionResourceAndRoleIdsDto.RoleId,
+                PermissionId = permissionResourceAndRoleIdsDto.PermissionId,
+                ResourceId = permissionResourceAndRoleIdsDto.ResourceId
+            };
+
+            _rolesPermissionsResourcesRepository.Add(rolePermissionResource);
+            await _rolesPermissionsResourcesRepository.SaveChangesAsync();
+
+            responseDto.Success.Add(new RolePermissionResourceResponseStatusDto
+            {
+                PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
+                Status = ResponseStatus.Success,
+                Message = "Success"
+            });
+        }
+
+        _logger.LogInformation(
+            "User with Id {authenticatedUserId} requested AssignPermissionToRoleAsync and the result was {responsesDto}",
+            authenticatedUserId, responseDto);
+
+        return responseDto;
     }
 
     public async Task<bool> ArePermissionNameResourceNameAssignedToRoleIdAsync(Guid roleId, string permissionName,
@@ -94,123 +199,15 @@ public class RolesPermissionsResourcesService : IRolesPermissionsResourcesServic
         return rolePermissionResource;
     }
 
-    public async Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> RevokePermissionsToRolesAsync(
-        PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto)
+    private void AddFailedResponseDto(ResponsesDto<RolePermissionResourceResponseStatusDto> responseDto,
+        PermissionResourceAndRoleIdsDto permissionResourceAndRoleIdsDto, string status, string field, string message)
     {
-        Guid authenticatedUserId = AuthenticatedUserId;
-        ResponsesDto<RolePermissionResourceResponseStatusDto> responsesDto = new();
-
-        _logger.LogInformation(
-            "User with Id {authenticatedUserId} requested RevokePermissionToRoleAsync with the object {permissionsResourcesAndRolesIdsDto}",
-            authenticatedUserId, permissionsResourcesAndRolesIdsDto);
-
-        foreach (PermissionResourceAndRoleIdsDto permissionResourceAndRoleIdsDto in permissionsResourcesAndRolesIdsDto
-            .PermissionResourceAndRoleIds)
+        responseDto.Failed.Add(new RolePermissionResourceResponseStatusDto
         {
-            RolePermissionResource? rolePermissionResource =
-                await GetByRoleIdPermissionIdResourceIdAsync(permissionResourceAndRoleIdsDto.RoleId,
-                    permissionResourceAndRoleIdsDto.PermissionId, permissionResourceAndRoleIdsDto.ResourceId);
-            
-            if (rolePermissionResource == null)
-            {
-                responsesDto.Failed.Add(new RolePermissionResourceResponseStatusDto {
-                    PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                    Status = ResponseStatus.NotFound,
-                    Field = "PermissionId",
-                    Message = "Permission not found"
-                }); continue;
-            }
-            
-            // Remove from database
-            _rolesPermissionsResourcesRepository.Remove(rolePermissionResource);
-            await _rolesPermissionsResourcesRepository.SaveChangesAsync();
-            
-            responsesDto.Success.Add(new RolePermissionResourceResponseStatusDto
-            {
-                PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                Status = ResponseStatus.Success,
-                Message = "Success"
-            });
-        }
-        
-        _logger.LogInformation(
-            "User with Id {authenticatedUserId} requested AssignPermissionToRoleAsync and the result was {responsesDto}",
-            authenticatedUserId, responsesDto);
-
-        return responsesDto;
-    }
-
-    public async Task<ResponsesDto<RolePermissionResourceResponseStatusDto>> AssignPermissionsToRolesAsync(
-            PermissionsResourcesAndRolesIdsDto permissionsResourcesAndRolesIdsDto)
-    {
-        Guid authenticatedUserId = AuthenticatedUserId;
-        ResponsesDto<RolePermissionResourceResponseStatusDto> responsesDto = new();
-
-        _logger.LogInformation(
-            "User with Id {authenticatedUserId} requested AssignPermissionToRoleAsync with the object {permissionsResourcesAndRolesIdsDto}",
-            authenticatedUserId, permissionsResourcesAndRolesIdsDto);
-
-        foreach (PermissionResourceAndRoleIdsDto permissionResourceAndRoleIdsDto in permissionsResourcesAndRolesIdsDto
-                     .PermissionResourceAndRoleIds)
-        {
-            if (await ArePermissionIdResourceIdAssignedToRoleIdAsync(permissionResourceAndRoleIdsDto.RoleId,
-                    permissionResourceAndRoleIdsDto.PermissionId, permissionResourceAndRoleIdsDto.ResourceId)) {
-                responsesDto.Failed.Add(new RolePermissionResourceResponseStatusDto {
-                    PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                    Status = ResponseStatus.AlreadyProcessed,
-                    Message = "Already assigned"
-                }); continue;
-            }
-
-            if (!await _roleService.ExistById(permissionResourceAndRoleIdsDto.RoleId)) {
-                responsesDto.Failed.Add(new RolePermissionResourceResponseStatusDto {
-                    PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                    Status = ResponseStatus.NotFound,
-                    Field = "RoleId",
-                    Message = "Role not found"
-                }); continue;
-            }
-
-            if (!await _permissionService.ExistById(permissionResourceAndRoleIdsDto.PermissionId)) {
-                responsesDto.Failed.Add(new RolePermissionResourceResponseStatusDto {
-                    PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                    Status = ResponseStatus.NotFound,
-                    Field = "PermissionId",
-                    Message = "Permission not found"
-                }); continue;
-            }
-
-            if (permissionResourceAndRoleIdsDto.ResourceId != null && !await _resourceService.ExistById(permissionResourceAndRoleIdsDto.ResourceId.Value)) {
-                responsesDto.Failed.Add(new RolePermissionResourceResponseStatusDto {
-                    PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                    Status = ResponseStatus.NotFound,
-                    Field = "ResourceId",
-                    Message = "Resource not found"
-                }); continue;
-            }
-
-            RolePermissionResource rolePermissionResource = new RolePermissionResource
-            {
-                RoleId = permissionResourceAndRoleIdsDto.RoleId,
-                PermissionId = permissionResourceAndRoleIdsDto.PermissionId,
-                ResourceId = permissionResourceAndRoleIdsDto.ResourceId
-            };
-
-            _rolesPermissionsResourcesRepository.Add(rolePermissionResource);
-            await _rolesPermissionsResourcesRepository.SaveChangesAsync();
-            
-            responsesDto.Success.Add(new RolePermissionResourceResponseStatusDto
-            {
-                PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
-                Status = ResponseStatus.Success,
-                Message = "Success"
-            });
-        }
-
-        _logger.LogInformation(
-            "User with Id {authenticatedUserId} requested AssignPermissionToRoleAsync and the result was {responsesDto}",
-            authenticatedUserId, responsesDto);
-
-        return responsesDto;
+            PermissionResourceAndRoleIds = permissionResourceAndRoleIdsDto,
+            Status = status,
+            Field = field,
+            Message = message
+        });
     }
 }

--- a/backend/Modules/Tokens/ITokenService.cs
+++ b/backend/Modules/Tokens/ITokenService.cs
@@ -8,7 +8,7 @@ public interface ITokenService
     Task<RefreshToken> GenerateAndStoreRefreshTokenAsync(Guid userId, string deviceId);
     Task<RefreshToken> GetRefreshTokenByRefreshTokenThrowsNotFound(string refreshToken);
     Task<RefreshToken> RevokeRefreshTokenByObject(RefreshToken refreshToken);
-    Task RevokeRefreshsTokensByUserId(Guid userId);
+    Task RevokeRefreshTokensByUserId(Guid userId);
     Task<bool> IsNewDevice(Guid userId, string deviceId);
     Task ValidateNumsOfDevices(Guid userId);
 }

--- a/backend/Modules/Users/UsersService.cs
+++ b/backend/Modules/Users/UsersService.cs
@@ -12,6 +12,7 @@ public interface IUsersService
 {
     Task<GetAllResponseDto<User>> GetAll(GetAllDto getAllDto);
     Task<User> GetByIdThrowsNotFoundAsync(Guid id);
+    Task<User?> GetById(Guid id);
     Task<User?> GetByUserName(string userName);
     Task<User?> GetByEmail(string email);
     Task<bool> ExistByIdThrowsNotFound(Guid id);
@@ -26,99 +27,50 @@ public interface IUsersService
     Task<ResponsesDto<UserResponseStatusDto>> ActivateUsersAsync(UsersIdsDto usersIdsDto);
 }
 
-public class UsersService : IUsersService
+public class UsersService(
+    IUsersRepository _usersRepository,
+    IGenericServie<User> _genericService,
+    ITokenService _tokenService, 
+    ILogger<UsersService> _logger, 
+    IHttpContextAccessor _httpContextAccessor,
+    IMailService _mailService, 
+    IPriorityValidationService _priorityValidationService
+    ) : IUsersService
 {
-    private readonly IUsersRepository _usersRepository;
-    private readonly ITokenService _tokenService;
-    private readonly IGenericServie<User> _genericService;
-    private readonly ILogger<UsersService> _logger;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly IMailService _mailService;
-
-    private Guid AuthenticatedUserId =>
-        Guid.Parse(_httpContextAccessor.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ??
-                   Guid.Empty.ToString());
-
-    public UsersService(IUsersRepository usersRepository, IGenericServie<User> genericService,
-        ITokenService tokenService, ILogger<UsersService> logger, IHttpContextAccessor httpContextAccessor,
-        IMailService mailService)
-    {
-        _usersRepository = usersRepository;
-        _genericService = genericService;
-        _tokenService = tokenService;
-        _logger = logger;
-        _httpContextAccessor = httpContextAccessor;
-        _mailService = mailService;
-    }
-
     public async Task<User> UpdateAsync(UpdateUserDto updateUserDto)
     {
-        Guid authenticatedUserId = AuthenticatedUserId;
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
 
-        _logger.LogInformation("User with Id {authenticatedUserId} requested UpdateUser with UserId {TargetUserId}",
+        _logger.LogInformation(
+            "User with Id {authenticatedUserId} requested UpdateUser with UserId {TargetUserId}",
             authenticatedUserId, updateUserDto.UserId);
 
-        // Get the user
-        User user = await this.GetByIdThrowsNotFoundAsync(updateUserDto.UserId);
+        User user = await GetByIdThrowsNotFoundAsync(updateUserDto.UserId);
 
-        bool hasChanges = false;
+        if (authenticatedUserId != updateUserDto.UserId)
+            _priorityValidationService.ValidateUserPriorityThrowsForbiddenException(user);
 
-        // Update user
-        if (updateUserDto.UserFirstName != null && updateUserDto.UserFirstName != user.UserFirstName)
+        bool hasChanges = ModelsHelper.UpdateModel(user, updateUserDto, async (field, value) =>
         {
-            user.UserFirstName = updateUserDto.UserFirstName;
-            hasChanges = true;
-        }
-
-        if (updateUserDto.UserLastName != null && updateUserDto.UserLastName != user.UserLastName)
-        {
-            user.UserLastName = updateUserDto.UserLastName;
-            hasChanges = true;
-        }
-
-        if (updateUserDto.UserUserName != null && updateUserDto.UserUserName != user.UserUserName)
-        {
-            if (await ExistByUserName(updateUserDto.UserUserName))
+            return field switch
             {
-                _logger.LogError(
-                    "User with Id {authenticatedUserId} requested UpdateUser but the user with username {UserUserName} already exists",
-                    authenticatedUserId, updateUserDto.UserUserName);
-                throw new UniqueConstraintViolationException(
-                    message: $"User with username {updateUserDto.UserUserName} already exists", field: "UserUserName");
-            }
-
-            user.UserUserName = updateUserDto.UserUserName;
-            hasChanges = true;
-        }
-
-        if (updateUserDto.UserEmail != null && updateUserDto.UserEmail != user.UserEmail)
-        {
-            // Check if the email is already in use
-            if (await ExistByEmail(updateUserDto.UserEmail))
-            {
-                _logger.LogError(
-                    "User with Id {authenticatedUserId} requested UpdateUser but the user with email {UserEmail} already exists",
-                    authenticatedUserId, updateUserDto.UserEmail);
-                throw new UniqueConstraintViolationException(
-                    message: $"User with email {updateUserDto.UserEmail} already exists", field: "UserEmail");
-            }
-
-            user.UserEmail = updateUserDto.UserEmail;
-            hasChanges = true;
-        }
+                nameof(updateUserDto.UserEmail) => await ExistByEmail((string)value),
+                nameof(updateUserDto.UserUserName) => await ExistByUserName((string)value),
+                _ => false
+            };
+        });
 
         if (hasChanges)
         {
             _logger.LogInformation(
-                "User with Id {authenticatedUserId} requested UpdateUser and the user was updated with Id {UpdatedUserId}",
+                "User with Id {authenticatedUserId} updated User with Id {UpdatedUserId}",
                 authenticatedUserId, user.UserId);
-            await this._usersRepository.SaveChangesAsync();
         }
         else
         {
             _logger.LogInformation(
-                "User with Id {authenticatedUserId} requested UpdateUser and the user was not updated with Id {UpdatedUserId}",
-                authenticatedUserId, updateUserDto.UserId);
+                "User with Id {authenticatedUserId} requested UpdateUser but no changes were made",
+                authenticatedUserId);
         }
 
         return user;
@@ -126,7 +78,7 @@ public class UsersService : IUsersService
 
     public async Task<User> ChangePasswordAsync(ChangePasswordDto changePasswordDto)
     {
-        Guid authenticatedUserId = AuthenticatedUserId;
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
 
         _logger.LogInformation("User with Id {authenticatedUserId} requested ChangePassword", authenticatedUserId);
 
@@ -154,7 +106,7 @@ public class UsersService : IUsersService
         user.UserPassword = HasherHelper.HashString(changePasswordDto.NewPassword);
 
         // Save changes
-        await this._usersRepository.SaveChangesAsync();
+        await _usersRepository.SaveChangesAsync();
 
         _logger.LogInformation(
             "User with Id {authenticatedUserId} requested ChangePassword and the password was changed",
@@ -165,7 +117,7 @@ public class UsersService : IUsersService
 
     public async Task<ResponsesDto<UserResponseStatusDto>> ActivateUsersAsync(UsersIdsDto usersIdsDto)
     {
-        Guid authenticatedUserId = AuthenticatedUserId;
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
         ResponsesDto<UserResponseStatusDto> responseDto = new();
 
         _logger.LogInformation(
@@ -177,29 +129,21 @@ public class UsersService : IUsersService
             User? user = await GetById(id);
             if (user == null)
             {
-                responseDto.Failed.Add(new UserResponseStatusDto
-                {
-                    UserId = id,
-                    Status = ResponseStatus.NotFound,
-                    Field = "UserId",
-                    Message = "User not found"
-                });
-                continue;
+                AddFailedResponseDto(responseDto, id, ResponseStatus.NotFound, "UserId", "User not found"); continue;
             }
 
             if (user.IsActive)
             {
-                responseDto.Failed.Add(new UserResponseStatusDto
-                {
-                    UserId = id,
-                    Status = ResponseStatus.AlreadyProcessed,
-                    Message = "User already activated"
-                });
-                continue;
+                AddFailedResponseDto(responseDto, id, ResponseStatus.AlreadyProcessed, "UserId", "User already activated"); continue;
             }
-
+            
+            if (authenticatedUserId != user.UserId && !_priorityValidationService.ValidateUserPriority(user))
+            {
+                AddFailedResponseDto(responseDto, id, ResponseStatus.NotEnoughPriority, "UserId", "Not have enough priority to activate that user"); continue;
+            }
+            
             user.IsActive = true;
-            await this._usersRepository.SaveChangesAsync();
+            await _usersRepository.SaveChangesAsync();
             responseDto.Success.Add(new UserResponseStatusDto
             {
                 UserId = id,
@@ -218,7 +162,7 @@ public class UsersService : IUsersService
 
     public async Task<ResponsesDto<UserResponseStatusDto>> DeactivateUsersAsync(UsersIdsDto usersIdsDto)
     {
-        Guid authenticatedUserId = AuthenticatedUserId;
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
         ResponsesDto<UserResponseStatusDto> responseDto = new();
 
         using var transaction = await _usersRepository.BeginTransactionAsync();
@@ -230,29 +174,21 @@ public class UsersService : IUsersService
                 User? user = await GetById(id);
                 if (user == null)
                 {
-                    responseDto.Failed.Add(new UserResponseStatusDto
-                    {
-                        UserId = id,
-                        Status = ResponseStatus.NotFound,
-                        Field = "UserId",
-                        Message = "User not found"
-                    });
-                    continue;
+                    AddFailedResponseDto(responseDto, id, ResponseStatus.NotFound, "UserId", "User not found"); continue;
                 }
 
                 if (!user.IsActive)
                 {
-                    responseDto.Failed.Add(new UserResponseStatusDto
-                    {
-                        UserId = id,
-                        Status = ResponseStatus.AlreadyProcessed,
-                        Message = "User was already deactivated"
-                    });
-                    continue;
+                    AddFailedResponseDto(responseDto, id, ResponseStatus.AlreadyProcessed, "UserId", "User was already deactivated"); continue;
+                }
+                
+                if (authenticatedUserId != user.UserId && !_priorityValidationService.ValidateUserPriority(user))
+                {
+                    AddFailedResponseDto(responseDto, id, ResponseStatus.NotEnoughPriority, "UserId", "Not have enough priority to deactivate that user"); continue;
                 }
 
                 user.IsActive = false;
-                await _tokenService.RevokeRefreshsTokensByUserId(id);
+                await _tokenService.RevokeRefreshTokensByUserId(id);
                 await _usersRepository.SaveChangesAsync();
 
                 responseDto.Success.Add(new UserResponseStatusDto
@@ -282,10 +218,11 @@ public class UsersService : IUsersService
 
     public async Task<User?> Create(CreateUserDto createUserDto)
     {
-        Guid authenticatedUserId = AuthenticatedUserId;
+        Guid authenticatedUserId = HttpContextHelper.GetAuthenticatedUserId(_httpContextAccessor);
 
         _logger.LogInformation("User with Id {authenticatedUserId} requested CreateUser with UserName {UserUserName}",
             authenticatedUserId, createUserDto.UserUserName);
+        
         if (await ExistByUserName(createUserDto.UserUserName))
         {
             _logger.LogError(
@@ -314,8 +251,8 @@ public class UsersService : IUsersService
             IsActive = createUserDto.IsActive
         };
 
-        this._usersRepository.Add(user);
-        await this._usersRepository.SaveChangesAsync();
+        _usersRepository.Add(user);
+        await _usersRepository.SaveChangesAsync();
 
         _logger.LogInformation(
             "User with Id {authenticatedUserId} requested CreateUser and the user was created with Id {CreatedUserId}",
@@ -332,7 +269,8 @@ public class UsersService : IUsersService
 
     public async Task<User?> GetById(Guid id)
     {
-        return await _genericService.GetById(id, query => query.Include(u => u.UserRoles).ThenInclude(ur => ur.Role));
+        return await _genericService.GetById(id, 
+            query => query.Include(u => u.UserRoles).ThenInclude(ur => ur.Role));
     }
 
     public async Task<User> GetByIdThrowsNotFoundAsync(Guid id)
@@ -379,5 +317,17 @@ public class UsersService : IUsersService
     public async Task<User?> GetByEmail(string email)
     {
         return await _genericService.GetFirstAsync(u => u.UserEmail, email);
+    }
+    
+    private void AddFailedResponseDto(ResponsesDto<UserResponseStatusDto> responseDto, Guid id, string status,
+        string field, string message)
+    {
+        responseDto.Failed.Add(new UserResponseStatusDto
+        {
+            UserId = id,
+            Status = status,
+            Field = field,
+            Message = message
+        });
     }
 }

--- a/backend/Modules/UsersRoles/UsersRolesController.cs
+++ b/backend/Modules/UsersRoles/UsersRolesController.cs
@@ -21,7 +21,7 @@ public class UsersRolesController : ControllerBase
     
     
     [HttpPost("assign-roles")]
-    [PermissionAuthorize("Assign_Role")]
+    [PermissionAuthorize("Assign_Role")] 
     public async Task<ActionResult<ResponsesDto<UserAndRoleResponseStatusDto>>> AssignRoles([FromBody] UsersAndRolesDtos usersAndRolesDto)
     {
         ResponsesDto<UserAndRoleResponseStatusDto> usersAndRolesResponsesDto = await _usersRolesService.AssignRolesToUsersAsync(usersAndRolesDto);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddScoped<IPermissionService, PermissionService>();
 builder.Services.AddScoped<IPermissionRepository, PermissionRepository>();
 builder.Services.AddScoped(typeof(IGenericServie<>), typeof(GenericService<>));
 builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+builder.Services.AddScoped<IPriorityValidationService, PriorityValidationService>();
 builder.Services.AddScoped<IMailService, MailService>();
 
 builder.Services.AddControllers();


### PR DESCRIPTION
- Added `rolePriority` field to `Role` table
- Stored roles priorities in authentication token
- Restricted user actions based on priority:
  - Users cannot modify, activate, deactivate, or assign roles to higher-priority users
  - Users cannot assign/revoke roles or permissions with higher priority
  - Users cannot create, update, or delete roles with higher priority